### PR TITLE
Track the top 13 repositories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ All tasks are defined as executable scripts in `mise-tasks/` and run via mise:
 mise run fetch-stats          # Fetch Homebrew analytics + GitHub stars
 mise run fetch-competitors    # Fetch mise vs asdf/just/brew comparison data
 mise run fetch-hk-competitors # Fetch hk competitor data
-mise run fetch-top-repos      # Fetch top 10 jdx repos
+mise run fetch-top-repos      # Fetch top 13 active repos
 mise run plot-stats           # Generate mise vs competitors chart
 mise run plot-hk-stats        # Generate hk chart
 mise run plot-fnox-stats      # Generate fnox chart

--- a/mise-tasks/fetch-top-repos.sh
+++ b/mise-tasks/fetch-top-repos.sh
@@ -2,7 +2,7 @@
 set -exuo pipefail
 
 DATE=$(date '+%Y-%m-%d')
-# Accounts scanned for the top 10. Top 10 is computed across the union.
+# Accounts scanned for the tracked repos. The ranking is computed across the union.
 GITHUB_USERS=("jdx" "endevco")
 # Default owner used when an entry has no "owner/" prefix; kept for back-compat
 # with older CSV rows that used the bare repo name.
@@ -42,8 +42,9 @@ done
 # Filter: exclude archived repos, forks, sample projects, and those not updated in >1 year
 # Calculate cutoff date as 1 year ago from today
 CUTOFF_DATE=$(date -u -v-1y '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '1 year ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "2024-10-26T00:00:00Z")
-# Track top 11 so the chart (which excludes mise) still shows 10 repos
-CURRENT_TOP_10=$(echo "$ALL_REPOS" | jq -r --arg cutoff "$CUTOFF_DATE" '
+# Track the top 13. The stars chart excludes mise and displays its top 10;
+# download collection covers every repository in this larger set.
+TRACKED_REPOS=$(echo "$ALL_REPOS" | jq -r --arg cutoff "$CUTOFF_DATE" '
     sort_by(-.stargazers_count) |
     .[] |
     select(
@@ -53,19 +54,17 @@ CURRENT_TOP_10=$(echo "$ALL_REPOS" | jq -r --arg cutoff "$CUTOFF_DATE" '
         (.name | test("sample|demo|example"; "i") | not)
     ) |
     .full_name
-' | head -11)
+' | head -13)
 
-# Replace the entire repos list with current top 11 across tracked accounts
+# Replace the entire repos list with the current top 13 across tracked accounts
 echo "# Top repos list - automatically managed" > "$REPOS_LIST_FILE"
-echo "# Top 11 active repos across tracked accounts (${GITHUB_USERS[*]}), refreshed regularly" >> "$REPOS_LIST_FILE"
-echo "# The chart excludes mise and shows the remaining 10" >> "$REPOS_LIST_FILE"
+echo "# Top 13 active repos across tracked accounts (${GITHUB_USERS[*]}), refreshed regularly" >> "$REPOS_LIST_FILE"
+echo "# The stars chart excludes mise and shows the top 10; downloads track all 13" >> "$REPOS_LIST_FILE"
 echo "# Filters: excludes archived repos, forks, sample/demo projects, and repos not updated in >1 year" >> "$REPOS_LIST_FILE"
 echo "# Entries use \"owner/repo\" format (bare \"repo\" is also accepted and assumed owned by $DEFAULT_OWNER)" >> "$REPOS_LIST_FILE"
-for repo in $CURRENT_TOP_10; do
+for repo in $TRACKED_REPOS; do
     echo "$repo" >> "$REPOS_LIST_FILE"
 done
-
-TRACKED_REPOS="$CURRENT_TOP_10"
 
 # Fetch Homebrew analytics data once
 BREW_DATA=$(curl -s https://formulae.brew.sh/api/analytics/install-on-request/30d.json)

--- a/mise-tasks/plot-top-repos.py
+++ b/mise-tasks/plot-top-repos.py
@@ -46,8 +46,8 @@ from datetime import datetime, timedelta
 two_years_ago = datetime.now() - timedelta(days=730)
 df = df[df['date'] >= two_years_ago]
 
-# Restrict to the currently tracked top 10 (excludes historical rows for
-# repos that dropped off the list)
+# Restrict to currently tracked repos (excludes historical rows for repos that
+# dropped off the list). The chart below still displays the top 10 excluding mise.
 tracked = read_tracked_repo_names()
 df = df[df['repo_name'].isin(tracked)]
 

--- a/top-repos-list.txt
+++ b/top-repos-list.txt
@@ -1,6 +1,6 @@
 # Top repos list - automatically managed
-# Top 11 active repos across tracked accounts (jdx endevco), refreshed regularly
-# The chart excludes mise and shows the remaining 10
+# Top 13 active repos across tracked accounts (jdx endevco), refreshed regularly
+# The stars chart excludes mise and shows the top 10; downloads track all 13
 # Filters: excludes archived repos, forks, sample/demo projects, and repos not updated in >1 year
 # Entries use "owner/repo" format (bare "repo" is also accepted and assumed owned by jdx)
 jdx/mise
@@ -14,3 +14,5 @@ jdx/demand
 jdx/communique
 jdx/pklr
 jdx/ruby
+jdx/mr-boxington
+jdx/tak


### PR DESCRIPTION
Expand the automatically managed repository set from 11 to 13 so GitHub release-download collection includes `mr-boxington` and `tak`.

The stars chart remains limited to the top 10 repositories excluding mise, while downloads are collected for all 13.

Validation:
- `bash -n mise-tasks/fetch-top-repos.sh`
- `uv run python -m py_compile mise-tasks/plot-top-repos.py mise-tasks/fetch-top-repos-downloads.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and comment changes to repo list size; no auth, data schema, or chart logic changes beyond two additional tracked repositories.
> 
> **Overview**
> Expands the auto-managed **top repos** set from **11 to 13** so daily fetch and release-download collection include **`jdx/mr-boxington`** and **`jdx/tak`**, while the stars chart behavior stays the same.
> 
> **`fetch-top-repos.sh`** now selects `head -13`, renames the selection to `TRACKED_REPOS`, and refreshes **`top-repos-list.txt`** with updated header comments (stars chart: top 10 excluding mise; downloads: all 13). **`plot-top-repos.py`** and **`CLAUDE.md`** only clarify that distinction—plotting still caps at the top 10 non-`mise` repos from the tracked list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9960081bef696d6656e0b56538dc04962f3911d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded repository tracking to include the top 13 active repositories.
  * Added two repositories to the tracked repository list.
  * Download metrics now cover all 13 tracked repositories.
  * Stars charts continue to display the top 10 repositories, excluding `mise`.

* **Documentation**
  * Updated repository and chart descriptions to clarify tracking and display rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->